### PR TITLE
Need less strict versions to use gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ PATH
   specs:
     concurrent_rails (0.1.0)
       rails (>= 5.0)
-      rubocop (= 1.12)
-      rubocop-performance (= 1.10)
 
 GEM
   remote: https://rubygems.org/
@@ -91,8 +89,6 @@ GEM
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.3-x86_64-darwin)
-      racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.1.0)
       ast (~> 2.4.1)
@@ -167,6 +163,8 @@ PLATFORMS
 
 DEPENDENCIES
   concurrent_rails!
+  rubocop (>= 1.12)
+  rubocop-performance (>= 1.10)
 
 BUNDLED WITH
    2.2.16

--- a/concurrent_rails.gemspec
+++ b/concurrent_rails.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails', '>= 5.0'
 
-  spec.add_runtime_dependency 'rubocop', '1.12'
-  spec.add_runtime_dependency 'rubocop-performance', '1.10'
+  spec.add_development_dependency 'rubocop', '>= 1.12'
+  spec.add_development_dependency 'rubocop-performance', '>= 1.10'
 
   spec.required_ruby_version = '>= 2.4'
 end


### PR DESCRIPTION
Those are development dependencies and conflict for local development when using the gem.