### PR TITLE
Require 'railties' instead of 'rails'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem 'sqlite3', '~> 1.6'
+gem 'activerecord' # needed for app_test test case
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]

--- a/concurrent_rails.gemspec
+++ b/concurrent_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri']   = 'https://github.com/luizkowalski/concurrent_rails/blob/master/CHANGELOG.md'
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  spec.add_dependency 'rails', '>= 5.2'
+  spec.add_dependency 'railties', '>= 5.2'
 
   spec.add_development_dependency 'minitest-reporters', '~> 1.5'
   spec.add_development_dependency 'rubocop', '>= 1.43'

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -13,7 +13,7 @@ require 'action_controller/railtie'
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require 'action_view/railtie'
-require 'action_cable/engine'
+# require 'action_cable/engine'
 # require "sprockets/railtie"
 require 'rails/test_unit/railtie'
 


### PR DESCRIPTION
Requiring 'rails' forces users to include portions of the rails framework they may not want.  This change allows users more choice in which portions of rails they install with their project.